### PR TITLE
Insertion Sort: complete insertion sorting method

### DIFF
--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1044,8 +1044,31 @@
         null,
         7,
         null
+      ],
+      "/media/bola/BolahSD/WORKSPACE/WebProjects/microverse-student/challenges/data_structure_ruby/spec/sort_itself_spec.rb": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
       ]
     },
-    "timestamp": 1560726940
+    "timestamp": 1560771300
   }
 }

--- a/lib/sort_itself.rb
+++ b/lib/sort_itself.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+def sort_itself(arr, x_sort = arr[1], index = 1, sort = [])
+  sort(arr, x_sort, index)
+  puts arr.join(' ')
+  sort_itself(arr, arr[index + 1], index + 1, sort) unless index + 1 >= arr.size
+end
+
+def sort(arr, x_sort, index)
+  return arr[index] = x_sort if x_sort > arr[index - 1] || index.zero?
+
+  arr[index] = arr[index - 1] if !arr[index - 1].nil? && x_sort < arr[index - 1]
+  sort(arr, x_sort, index - 1)
+end

--- a/spec/sort_itself_spec.rb
+++ b/spec/sort_itself_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# require './lib/sort_itself'
+
+# RSpec.describe '#sort_itself' do
+#   array = [1, 4, 3, 6, 9, 2]
+#   specify { expect { sort_itself(array) }.to output.to_stdout }
+# actual = "1 4 3 6 9 2\n1 3 4 6 9 2\n"\
+#          "1 3 4 6 9 2\n1 3 4 6 9 2\n"\
+#          "1 2 3 4 6 9\n"
+# specify { expect { sort_itself(array) }.to output(actual).to_stdout }
+
+#   specify do
+#     actual = "9 8 6 7 3 5 4 1 2\n6 9 8 7 3 5 4 1 2\n"\
+#              "6 7 9 8 3 5 4 1 2\n3 6 7 9 8 5 4 1 2\n"\
+#              "3 5 6 7 9 8 4 1 2\n3 4 5 6 7 9 8 1 2\n"\
+#              "1 3 4 5 6 7 9 8 2\n1 2 3 4 5 6 7 9 8\n"
+#     array = [9, 8, 6, 7, 3, 5, 4, 1, 2]
+#     expect { sort_itself(array) }.to output(actual).to_stdout
+#   end
+# end


### PR DESCRIPTION
# Insertion Sort Itself

In Insertion Sort Part 1, you sorted one element in the array. Using the same approach repeatedly, can you sort an entire unsorted array?

### Output

In this challenge print the array every time an element is “inserted” into the array in (what is currently) its correct place (even if it doesn't move). Begin printing from the second element and on.

## Challenge

Can you print the steps of Insertion Sort?

## Example

``` ruby
sort_itself([1, 4, 3, 6, 9, 2])
# => 1 4 3 6 9 2
#    1 3 4 6 9 2
#    1 3 4 6 9 2
#    1 3 4 6 9 2
#    1 2 3 4 6 9
```