### PR TITLE
Merge Sort: (Sorting Algorithm) 

### DIFF
--- a/lib/full_merge_sort.rb
+++ b/lib/full_merge_sort.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+def full_merge_sort(array)
+  arr = divide_merge_sort(array)
+  sorted_array = []
+  arr.each { |i| sorted_array << i.split(' ')[1] }
+  sorted_array
+end
+
+def divide_merge_sort(array, left = 0, right = array.size - 1)
+  return array if left >= right
+
+  half = (left + right) / 2
+  arr1 = divide_merge_sort(array[left..half])
+  arr2 = divide_merge_sort(array[(half + 1)..right])
+  f_merge_sort(arr1, arr2)
+end
+
+def f_merge_sort(arr1, arr2, arr = [], left = 0, right = 0)
+  diff = f_compare_array(arr1, arr2, left, right)
+  if diff
+    left = f_merge_left(arr1, arr, left)
+  else
+    right = f_merge_right(arr2, arr, right)
+  end
+
+  return arr.concat(arr2[right..-1]) if left >= arr1.size
+  return arr.concat(arr1[left..-1]) if right >= arr2.size
+
+  f_merge_sort(arr1, arr2, arr, left, right)
+end
+
+def f_compare_array(arr1, arr2, left, right)
+  diff = arr1[left].split(' ')[0].to_i - arr2[right].split(' ')[0].to_i
+  !diff.positive?
+end
+
+def f_merge_left(arr1, arr, left)
+  arr << arr1[left]
+  left += 1
+  left
+end
+
+def f_merge_right(arr2, arr, right)
+  arr << arr2[right]
+  right += 1
+  right
+end

--- a/lib/merge_sort.rb
+++ b/lib/merge_sort.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+def merge_sort(arr1, arr2, arr = [], left = 0, right = 0)
+  if (arr1[left] - arr2[right]).negative?
+    left = merge_left(arr1, arr, left)
+  else
+    right = merge_right(arr2, arr, right)
+  end
+
+  return arr.concat(arr2[right..-1]) if left >= arr1.size
+  return arr.concat(arr1[left..-1]) if right >= arr2.size
+
+  merge_sort(arr1, arr2, arr, left, right)
+  arr
+end
+
+def merge_left(arr1, arr, left)
+  arr << arr1[left]
+  left += 1
+  left
+end
+
+def merge_right(arr2, arr, right)
+  arr << arr2[right]
+  right += 1
+  right
+end

--- a/spec/full_merge_sort_spec.rb
+++ b/spec/full_merge_sort_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require './lib/full_merge_sort'
+
+RSpec.describe '#full_merge_sort' do
+  let(:array) do
+    ['0 ab', '6 cd', '0 ef', '6 gh', '4 ij', '0 ab',
+     '6 cd', '0 ef', '6 gh', '0 ij', '4 that', '3 be',
+     '0 to', '1 be', '5 question', '1 or', '2 not',
+     '4 is', '2 to', '4 the']
+  end
+  it { expect(full_merge_sort(array)).to be_an(Array) }
+
+  it 'should be an array of strings' do
+    expect(full_merge_sort(array).first).to be_a(String)
+  end
+
+  it 'checks an array of twenty positions' do
+    actual = %w[ab ef ab ef ij to
+                be or not to be ij
+                that is the question cd gh
+                cd gh]
+    expect(full_merge_sort(array)).to eql(actual)
+  end
+end

--- a/spec/merge_sort_spec.rb
+++ b/spec/merge_sort_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require './lib/merge_sort'
+
+RSpec.describe '#merge_sort' do
+  let(:arr1) { [1, 3, 9, 11] }
+  let(:arr2) { [2, 4, 6, 8] }
+  it 'checks if it merges two arrays into an array' do
+    expect(merge_sort(arr1, arr2)).to be_an(Array)
+  end
+
+  it 'checks an array of eight positions' do
+    expect(merge_sort(arr1, arr2)).to eql([1, 2, 3, 4, 6, 8, 9, 11])
+  end
+
+  let(:array_of_first_ten_positions_1) { [-3, 2, 2, 2, 4] }
+  let(:array_of_first_ten_positions_2) { [-2, 0, 1, 5, 7] }
+
+  it 'checks an array of first ten positions' do
+    expect(merge_sort(
+             array_of_first_ten_positions_1, array_of_first_ten_positions_2
+           )).to eql([-3, -2, 0, 1, 2, 2, 2, 4, 5, 7])
+  end
+
+  let(:array_of_second_ten_positions_1) { [-4, -3, -1, 1, 3] }
+  let(:array_of_second_ten_positions_2) { [0, 5, 7, 9, 11] }
+
+  it 'checks an array of second ten positions' do
+    expect(merge_sort(
+             array_of_second_ten_positions_1, array_of_second_ten_positions_2
+           )).to eql([-4, -3, -1, 0, 1, 3, 5, 7, 9, 11])
+  end
+end
+
+RSpec.describe '#merge_sort' do
+  let(:first_array_of_twelve_positions_1) { [21, 32, 45, 62, 71, 83] }
+  let(:first_array_of_twelve_positions_2) { [1, 3, 4, 7, 9, 12] }
+
+  it 'checks an array of first twelve positions' do
+    expect(merge_sort(
+             first_array_of_twelve_positions_1,
+             first_array_of_twelve_positions_2
+           )).to eql([1, 3, 4, 7, 9, 12, 21, 32, 45, 62, 71, 83])
+  end
+
+  let(:second_array_of_twelve_positions_1) { [-91, -4, 42, 121, 265, 530] }
+  let(:second_array_of_twelve_positions_2) { [-623, -54, -7, 651, 721, 850] }
+
+  it 'checks an array of second twelve positions' do
+    expect(merge_sort(
+             second_array_of_twelve_positions_1,
+             second_array_of_twelve_positions_2
+           )).to eql([-623, -91, -54, -7, -4, 42, 121, 265, 530, 651, 721, 850])
+  end
+end


### PR DESCRIPTION
# Merge Sort

## 1. Merge Sort I

Like QuickSort, MergeSort runs quickly in `O(n log n)` time. While Mergesort uses more space and is not usually as fast (in practice) as Quicksort, Mergesort has the benefit of being stable, which means it keeps duplicate elements in the original order that they started with. This is meaningless if the values being sorted is all there is, but usually there's associated data with each element which sometimes needs to be preserved in the original order. For example, if you sort by one value of an item, and then by another value, you may not want the second sort to mess up the order of the first sort.

### Stable Sort Example

Sort a deck of card so the suits are in order and each suit is in number-order.

#### Answer:
0 - Start with an unsorted deck
1 - Sort the entire deck by number
2 - Use a stable sort and sort by suit. Since the sort is stable, the number order is preserved.
See each step below:

![Merge sort example](https://res.cloudinary.com/bolaah/image/upload/v1561678000/github-microverse-project/mergesort1.png)

### Merge Method

The main part of MergeSort involves the merge method, which merges 2 sorted arrays to create one sorted array. This can be done in one pass through the arrays, by comparing the values of the two arrays before placing a value in the large array.

### Challenge

You are given two sorted arrays. Can you merge the them and return one sorted array? This should be done with only one run through the array.

### Example

``` ruby
p merge_sort([1, 3, 9, 11], [2, 4, 6, 8])
# => [1, 2, 3, 4, 6, 8, 9, 11]
```

