### PR TITLE
Index Match algorithm

### DIFF
--- a/lib/index_match.rb
+++ b/lib/index_match.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+def index_match(
+  arr, len = arr.size - 1, index = (0..len).to_a,
+  left = 0, right = arr.size - 1
+)
+  return index[0] if index[0] == arr[left]
+  return -1 if index[0] >= len
+
+  return false if left >= right
+
+  half = (left + right) / 2
+  recursive_index_match(arr, index, [left, half, right], len)
+end
+
+def recursive_index_match(arr, index, pos, len)
+  left = pos[0]
+  half = pos[1]
+  right = pos[2]
+  index_match(arr[left..half], len, index[left..half]) ||
+    index_match(arr[(half + 1)..right], len, index[(half + 1)..right])
+end

--- a/spec/index_match_spec.rb
+++ b/spec/index_match_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require './lib/index_match'
+
+RSpec.describe '#index_match' do
+  let(:array) { [0, 2, 3, 7, 9, 11] }
+
+  it { expect(index_match(array)).to be_an(Integer) }
+
+  it 'checks an array of six positions' do
+    expect(index_match(array)).to eql(0)
+  end
+
+  let(:array_of_seven_positions) { [3, 5, 7, 9, 11, 13, 17] }
+
+  it 'checks an array of seven positions' do
+    expect(index_match(array_of_seven_positions)).to eql(-1)
+  end
+
+  let(:array_of_eight_positions) { [-4, -2, 0, 2, 4, 6, 8, 10] }
+
+  it 'checks an array of eight positions' do
+    expect(index_match(array_of_eight_positions)).to eql(4)
+  end
+
+  let(:array_of_ten_positions) { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }
+
+  it 'checks an array of ten positions' do
+    expect(index_match(array_of_ten_positions)).to eql(-1)
+  end
+
+  let(:array_of_twelve_positions) do
+    [-20, -15, -11, 2, 5, 7, 10, 11, 12, 13, 14, 14]
+  end
+
+  it 'checks an array of twelve positions' do
+    expect(index_match(array_of_twelve_positions)).to eql(-1)
+  end
+end


### PR DESCRIPTION
# Index Match

Given a sorted array of integers with no duplicates, find the spot where `array[i] == i`.
It's super-easy to find a solution in `O(n)` time, but can you code an `O(log n)` solution?

### Challenge

Return the index where they match, or -1 if there is none.

### Example

``` ruby
puts index_match([0, 2, 3, 7, 9, 11])
# => 0
```